### PR TITLE
Added support for Macs running ARM64

### DIFF
--- a/alpaca.rb
+++ b/alpaca.rb
@@ -1,12 +1,24 @@
 class Alpaca < Formula
     desc "A local HTTP proxy for command-line tools. Supports PAC scripts and NTLM authentication."
     homepage "https://github.com/samuong/alpaca"
-    url "https://github.com/samuong/alpaca/releases/download/v1.2.0/alpaca_v1.2.0_darwin-amd64"
-    sha256 "d21e2119e907a212e7b3ea28a6b9e7fd2723dc44be94b2d6c4b5c13398078172"
+    if OS.mac? && Hardware::CPU.intel?
+        url "https://github.com/samuong/alpaca/releases/download/v1.2.0/alpaca_v1.2.0_darwin-amd64"
+        sha256 "d21e2119e907a212e7b3ea28a6b9e7fd2723dc44be94b2d6c4b5c13398078172"
+    end
+    if OS.mac? && !Hardware::CPU.intel?
+        url "https://github.com/samuong/alpaca/releases/download/v1.2.0/alpaca_v1.2.0_darwin-arm64"
+        sha256 "0231da653167609b77ee3ee8d2542bf700a85cdb3270aa72e8c2fc91e761bc84"
+    end
     version "1.2.0"
 
     def install
-        bin.install "alpaca_v1.2.0_darwin-amd64" => "alpaca"
+        if OS.mac? && Hardware::CPU.intel?
+            bin.install "alpaca_v1.2.0_darwin-amd64" => "alpaca"
+        
+        end
+        if OS.mac? && !Hardware::CPU.intel?
+            bin.install "alpaca_v1.2.0_darwin-arm64" => "alpaca"
+        end
     end
 
     plist_options :startup => true


### PR DESCRIPTION
This PR will allow macs running apple arm64 cpus to tap alpaca